### PR TITLE
Support for "gateway" mode. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,16 @@ subscriber-console: subscriber-release
 subscriber: subscriber-release
 	$(BASEDIR)/_build/subscriber/rel/$(APPNAME)/bin/$(APPNAME) start
 
+gateway-release: id
+	$(REBAR) as gateway release
+
+gateway-console: gateway-release
+	$(BASEDIR)/_build/gateway/rel/$(APPNAME)/bin/$(APPNAME) console
+
+gateway: gateway-release
+	$(BASEDIR)/_build/gateway/rel/$(APPNAME)/bin/$(APPNAME) start
+
+
 dialyzer: test
 	$(REBAR) dialyzer
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ provided `gen_xaptum` behavior to handle incoming messages.  If not set, a
 default `dummy_message_handler` that simply prints the message to console is
 used.
 
+xaptum_client can be run as a 
+1. single device or subscriber (`single` mode)
+1. gateway with multiple devices and/or subscribers (`multi` mode)
 
-## Usage
+## Single Mode Usage
 
 The client can either be a device that sends messages to queues or a
 subscriber that reads messages from these queues and sends control messages
@@ -65,6 +68,29 @@ To test receiving messages from device queues and sending messages to a device:
 Unlike device messages, control messages are received as-is, not as a
 base64-encoded payload in a JSON string.
 
+
+## Multi Mode Usage
+
+1. Run gateway client.
+   
+   `make gateway-console`
+   
+1. Start device(s)
+   
+    `xaptum_device:start(DeviceIpv6, DeviceUser, DeviceToken)`
+    
+1. Start subscriber(s)
+   
+    `xaptum_subscriber:start(SubscriberIpv6, SubUser, SubToken, Queue)`
+
+1. Device sends regular message 
+    
+    `xaptum_device:send_message(SrcDeviceIpv6, Message)`
+    
+1. Subscriber sends control message to device
+    
+    `xaptum_subscriber:send_message(SrcSubscriberIpv6, Message, DestDeviceIpv6)`
+    
 
 ### Code
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ xaptum_client can be run as a
 1. single device or subscriber (`single` mode)
 1. gateway with multiple devices and/or subscribers (`multi` mode)
 
-## Single Mode Usage
+## Single (or device/subscriber) Mode Usage
 
 The client can either be a device that sends messages to queues or a
 subscriber that reads messages from these queues and sends control messages
@@ -69,7 +69,7 @@ Unlike device messages, control messages are received as-is, not as a
 base64-encoded payload in a JSON string.
 
 
-## Multi Mode Usage
+## Multi (or gateway) Mode Usage
 
 1. Run gateway client.
    
@@ -77,19 +77,27 @@ base64-encoded payload in a JSON string.
    
 1. Start device(s)
    
-    `xaptum_device:start(DeviceIpv6, DeviceUser, DeviceToken)`
+    `xaptum_device:start(DeviceIpv6Str, DeviceUser, DeviceToken)` or
+    
+    `xaptum_device:start(DeviceIpv6Str, DeviceUser, DeviceToken, RegNameAtom)`
     
 1. Start subscriber(s)
    
-    `xaptum_subscriber:start(SubscriberIpv6, SubUser, SubToken, Queue)`
+    `xaptum_subscriber:start(SubscriberIpv6Str, SubUser, SubToken, Queue)`  or
+    
+    `xaptum_subscriber:start(SubscriberIpv6Str, SubUser, SubToken, Queue, RegNameAtom)`
 
 1. Device sends regular message 
     
-    `xaptum_device:send_message(SrcDeviceIpv6, Message)`
+    `xaptum_device:send_message(SrcDeviceIpv6Str, Message)` or
+    
+    `xaptum_device:send_message(RegNameAtom, Message)`
     
 1. Subscriber sends control message to device
     
-    `xaptum_subscriber:send_message(SrcSubscriberIpv6, Message, DestDeviceIpv6)`
+    `xaptum_subscriber:send_message(SrcSubscriberIpv6Str, Message, DestDeviceIpv6Str)` or
+    
+    `xaptum_subscriber:send_message(RegNameAtom, Message, DestDeviceIpv6Str)`
     
 
 ### Code

--- a/include/definitions.hrl
+++ b/include/definitions.hrl
@@ -25,6 +25,6 @@
 
 -define(AUTH_INFO_SIZE, (?GUID_SIZE + ?USER_SIZE + ?TOKEN_SIZE)).
 
--record(creds, {guid, user, token, session_token, queue}).
+-record(creds, {guid, user, token, session_token, queue, reg_name}).
 
 -endif.

--- a/rebar.config
+++ b/rebar.config
@@ -30,5 +30,7 @@
   {device, [{relx, [{dev_mode, false}, {include_erts, true}, {include_src, false},
     {overlay_vars, ["./templates/vars.config", "./templates/vars_device.config"]}]}]},
   {subscriber, [{relx, [{dev_mode, false}, {include_erts, true}, {include_src, false},
-    {overlay_vars, ["./templates/vars.config", "./templates/vars_subscriber.config"]}]}]}
+    {overlay_vars, ["./templates/vars.config", "./templates/vars_subscriber.config"]}]}]},
+  {gateway, [{relx, [{dev_mode, false}, {include_erts, true}, {include_src, false},
+    {overlay_vars, ["./templates/vars.config", "./templates/vars_gateway.config"]}]}]}
 ]}.

--- a/src/gen_xaptum.erl
+++ b/src/gen_xaptum.erl
@@ -39,8 +39,8 @@
 
 start_link(Type, single, #creds{} = Creds) ->
   gen_server:start_link({local, Type}, ?MODULE, [Type, Creds], []);
-start_link(Type, multi, #creds{guid = Guid} = Creds) when is_list(Guid) ->
-  gen_server:start_link({local, list_to_atom(Guid)}, ?MODULE, [Type, Creds], []).
+start_link(Type, multi, #creds{reg_name = RegName} = Creds) when is_atom(RegName) ->
+  gen_server:start_link({local, RegName}, ?MODULE, [Type, Creds], []).
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/src/gen_xaptum.erl
+++ b/src/gen_xaptum.erl
@@ -1,8 +1,9 @@
 %%%-------------------------------------------------------------------
 %%% @author iguberman
 %%% @copyright (C) 2017, Xaptum, Inc.
-%%% @doc
+%%%
 %%% gen_xaptum is a gen_server implementing xaptum communication protocol
+%%%
 %%% @end
 %%% Created : 27. Mar 2017 12:01 AM
 %%%-------------------------------------------------------------------
@@ -10,15 +11,9 @@
 -behaviour(gen_server).
 -author("iguberman").
 
--define(XAPTUM_SUB_GUID, "XAPTUM_SUB_GUID").
--define(XAPTUM_SUB_USER, "XAPTUM_SUB_USER").
--define(XAPTUM_SUB_TOKEN, "XAPTUM_SUB_TOKEN").
-
 %% API
 -export([
-  start_link/0,
-  start_device/3,
-  start_subscriber/4]).
+  start_link/3]).
 
 %% gen_server callbacks
 -export([init/1,
@@ -42,51 +37,22 @@
 %%% API
 %%%===================================================================
 
-start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
-
-start_device(Guid, User, Token)->
-  gen_server:start_link({local, Guid}, ?MODULE, [Guid, User, Token, ?DEVICE], []).
-
-start_subscriber(Guid, User, Token, Queue)->
-  gen_server:start_link({local, Guid}, ?MODULE, [Guid, User, Token, Queue, ?SUBSCRIBER], []).
+start_link(Type, single, #creds{} = Creds) ->
+  gen_server:start_link({local, Type}, ?MODULE, [Type, Creds], []);
+start_link(Type, multi, #creds{guid = Guid} = Creds) when is_list(Guid) ->
+  gen_server:start_link({local, list_to_atom(Guid)}, ?MODULE, [Type, Creds], []).
 
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
 
-init([]) ->
-  {ok, Type} = get_type(),
-
-%%  application:ensure_started(lager),
-
-  Guid = application:get_env(xaptum_client, guid, undefined),
-  User = application:get_env(xaptum_client, user, undefined),
-  Token = application:get_env(xaptum_client, token, undefined),
-
-  {ok, Creds} = Type:populate_credentials(Guid, User, Token),
+init([Type, Creds]) ->
 
   lager:info("Starting ~p with credentials: ~p", [Type, Creds]),
 
   State = init_state(#state{creds = Creds, type = Type}),
 
-  start(State);
-init([Guid, User, Token, Queue, ?SUBSCRIBER])->
-  lager:info("Starting xaptum subscriber on ~p", [node()]),
-  State = init_state(#state{creds = #creds{guid = Guid, user = User, token = Token, queue = Queue}, type = ?SUBSCRIBER}),
-  start(State);
-init([Guid, User, Token, ?DEVICE])->
-  lager:info("Starting xaptum device on ~p", [node()]),
-  State = init_state(#state{creds = #creds{guid = Guid, user = User, token = Token}, type = ?DEVICE}),
   start(State).
-
-get_type()->
-  case application:get_env(type) of
-    {ok, ?SUBSCRIBER} -> {ok, ?SUBSCRIBER};
-    {ok, ?DEVICE} -> {ok, ?DEVICE};
-    {ok, Type} -> {error, invalid_type, Type};
-    undefined -> {error, client_type_undefined}
-  end.
 
 start(#state{} = State)->
   gen_server:cast(self(), authenticate),
@@ -104,7 +70,6 @@ init_state(#state{creds = #creds{guid = Guid, user = User, token = Token} = Cred
     client_ip = LocalIp,
     handler = MessageHandler}.
 
-
 handle_call(_Request, _From, State) ->
   lager:warning("Don't know how to handle_call(~p, ~p, ~p)", [_Request, _From, State]),
   {reply, unsupported, State}.
@@ -116,13 +81,13 @@ handle_cast(authenticate, State) ->
 handle_cast(receive_message, State) ->
   start_message_receiver(State),
   {noreply, State};
-handle_cast({send_message, Payload, DestinationIp}, #state{socket = Socket, creds = Creds, type = ?SUBSCRIBER} = State) ->
+handle_cast({send_message, Payload, DestinationIp}, #state{socket = Socket, creds = Creds, type = xaptum_subscriber} = State) ->
   Guid = convert_from_Ipv6Text(DestinationIp),
-  DDSMessage = ?SUBSCRIBER:generate_message_request(Creds, Payload, Guid),
+  DDSMessage = xaptum_subscriber:generate_message_request(Creds, Payload, Guid),
   gen_tcp:send(Socket, DDSMessage),
   {noreply, State};
-handle_cast({send_message, Payload}, #state{socket = Socket, creds = Creds, type = ?DEVICE} = State) ->
-  DDSMessage = ?DEVICE:generate_message_request(Creds, Payload),
+handle_cast({send_message, Payload}, #state{socket = Socket, creds = Creds, type = xaptum_device} = State) ->
+  DDSMessage = xaptum_device:generate_message_request(Creds, Payload),
   gen_tcp:send(Socket, DDSMessage),
   {noreply, State};
 handle_cast(_Other, State) ->
@@ -175,11 +140,11 @@ start_message_receiver(#state{socket = Socket, creds = #creds{session_token = Se
 
 receive_message(ParentPid, #state{socket = Socket, creds = #creds{session_token = SessionToken}, type = Type, handler = Handler} = State) ->
   case receive_request_raw(Socket, 10000) of
-     {ok, ?CONTROL_MSG, _PayloadSize, <<ASessionToken:?SESSION_TOKEN_SIZE/bytes, Payload/binary>>} ->
-       case Type of
-         ?DEVICE -> ASessionToken = SessionToken;
-         ?SUBSCRIBER -> ok
-       end,
+    {ok, ?CONTROL_MSG, _PayloadSize, <<ASessionToken:?SESSION_TOKEN_SIZE/bytes, Payload/binary>>} ->
+      case Type of
+        xaptum_device -> ASessionToken = SessionToken;
+        xaptum_subscriber -> ok
+      end,
       Handler:async_handle_message(Payload),
       receive_message(ParentPid, State);
     {error, timeout} -> % no requests within the timeout, keep trying

--- a/src/xaptum_client.app.src
+++ b/src/xaptum_client.app.src
@@ -8,7 +8,7 @@
     stdlib
    ]},
   {env,[]},
-  {modules, []},
+  {modules, [gen_xaptum, xaptum_device, xaptum_subscriber]},
 
   {contributors, []},
   {licenses, []},

--- a/src/xaptum_client_app.erl
+++ b/src/xaptum_client_app.erl
@@ -8,20 +8,58 @@
 -behaviour(application).
 
 %% Application callbacks
--export([start/2
-        ,stop/1]).
+-export([
+  start/2,
+  stop/1]).
 
 %%====================================================================
 %% API
 %%====================================================================
 
 start(_StartType, _StartArgs) ->
-    'xaptum_client_sup':start_link().
+  Ret = 'xaptum_client_sup':start_link(),
+  maybe_create_device_or_subscriber(),
+  Ret.
 
 %%--------------------------------------------------------------------
 stop(_State) ->
-    ok.
+  ok.
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
+
+maybe_create_device_or_subscriber()->
+  case get_type() of
+    {ok, Type} -> create_single_entity(Type); %% proceed to creating device or subscriber
+    undefined -> ok %% not creating device or subscriber at this time
+  end.
+
+create_single_entity(Type)->
+  Guid = application:get_env(xaptum_client, guid, undefined),
+  User = application:get_env(xaptum_client, user, undefined),
+  Token = application:get_env(xaptum_client, token, undefined),
+
+  case Type:populate_credentials(Guid, User, Token) of
+    %% Env is setup to run a single device or subscriber
+    {ok, Creds} -> xaptum_client_sup:create(Type, single, Creds);
+    %% Env is not set, device(s) or subscriber(s) will be created on the fly
+    {warning, _Warning} ->
+      Type:not_created_warning_log(),
+      ok;
+    {error, Guid, Error} ->
+      lager:error("Error starting ~p for ~p: ~p", [Type, Guid, Error]),
+      {error, invalid_env}
+  end.
+
+
+get_type()->
+  case application:get_env(type) of
+    {ok, xaptum_subscriber} -> {ok, xaptum_subscriber};
+    {ok, xaptum_device} -> {ok, xaptum_device};
+    %% if it's a gateway, multiple devices/subscribers can be created from the console,
+    %% no need to set env for a single device or subscriber
+    {ok, xaptum_gateway } -> undefined;
+    {ok, Type} -> {error, invalid_type, Type};
+    undefined -> undefined
+  end.

--- a/src/xaptum_client_sup.erl
+++ b/src/xaptum_client_sup.erl
@@ -11,11 +11,13 @@
 -export([start_link/0]).
 
 %% Supervisor callbacks
--export([init/1]).
+-export([
+  init/1,
+  create/3]).
 
 -define(SERVER, ?MODULE).
 
--include("definitions.hrl").
+-include("../include/definitions.hrl").
 
 %%====================================================================
 %% API functions
@@ -24,14 +26,19 @@
 start_link() ->
   supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
+create(Type, Mode, #creds{} = Creds)->
+  supervisor:start_child(?MODULE, [Type, Mode, Creds]). %% calls gen_xaptum:start_link(Type, Mode, Creds)
+
 %%====================================================================
 %% Supervisor callbacks
 %%====================================================================
 
 %% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
 init([]) ->
-  RestartStrategy = {one_for_one, 60, 3600},
+  RestartStrategy = {simple_one_for_one, 60, 3600},
+
   Children = [#{id => gen_xaptum, start => {gen_xaptum, start_link, []}, shutdown => 1000}],
+
   {ok, {RestartStrategy, Children}}.
 
 

--- a/src/xaptum_device.erl
+++ b/src/xaptum_device.erl
@@ -3,8 +3,6 @@
 %%% @copyright (C) 2017, Xaptum, Inc.
 %%% @doc
 %%%
-%%% device specific functionality to be used by gen_xaptum when type = device
-%%%
 %%% @end
 %%% Created : 08. May 2017 11:12 AM
 %%%-------------------------------------------------------------------
@@ -19,23 +17,35 @@
 
 %% API
 -export([
+  start/3,
   send_message/1,
+  send_message/2,
   populate_credentials/3,
   generate_auth_request/1,
-  generate_message_request/2]).
+  generate_message_request/2,
+  not_created_warning_log/0]).
 
+%% This method is for creating device(s) on the fly
+start(Guid, User, Token)->
+  xaptum_client_sup:create(?MODULE, multi, #creds{guid = Guid, user = User, token = Token}).
+
+%% When single device is created from env, the message will be sent to the one device identified by env
 send_message(Message) ->
-  gen_server:cast(gen_xaptum, {send_message, Message}).
+  gen_server:cast(?MODULE, {send_message, Message}).
+
+%% When multiple devices are created on the fly, need to identify device by Guid when sending a message
+send_message(Guid, Message) when is_list(Guid)->
+  gen_server:cast(list_to_atom(Guid), {send_message, Message}).
 
 populate_credentials(undefined, _User, _Token)->
   case os:getenv(?XAPTUM_DEV_GUID) of
-    false -> {error, "No XAPTUM_DEV_GUID in env!"};
+    false -> {warning, "No XAPTUM_DEV_GUID in env!"};
     Guid ->
       case os:getenv(?XAPTUM_DEV_USER) of
-        false -> {error, "No XAPTUM_DEV_USER in env!"};
+        false -> {error, Guid, "No XAPTUM_DEV_USER in env!"};
         User ->
           case os:getenv(?XAPTUM_DEV_TOKEN) of
-            false -> {error, "No XAPTUM_DEV_TOKEN in env!"};
+            false -> {error, Guid, "No XAPTUM_DEV_TOKEN in env!"};
             Token ->
               lager:info("Device credentials from system env: guid = ~p, user = ~p, token = ~p ", [Guid, User, Token]),
               {ok, #creds{guid = Guid, user = User, token = Token}}
@@ -59,3 +69,6 @@ generate_message_request(#creds{guid = Guid, session_token = SessionToken}, Mess
   lager:info("Sending message from ~p with SessionToken ~p: ~p", [Guid, SessionToken, Message]),
   Size = ?SESSION_TOKEN_SIZE + size(Message),
   <<?DDS_MARKER, ?REG_MSG, Size:16, SessionToken:?SESSION_TOKEN_SIZE/bytes, Message/binary>>.
+
+not_created_warning_log()->
+  lager:warning("Device not created.  Call device:start(Guid, User, Token) to create device(s). ~nTo create device on app startup:~nEither set guid, user, and token app env or XAPTUM_DEV_GUID, XAPTUM_DEV_USER, and XAPTUM_DEV_TOKEN sys env and restart xaptum_client app").

--- a/src/xaptum_device.erl
+++ b/src/xaptum_device.erl
@@ -18,6 +18,7 @@
 %% API
 -export([
   start/3,
+  start/4,
   send_message/1,
   send_message/2,
   populate_credentials/3,
@@ -26,8 +27,11 @@
   not_created_warning_log/0]).
 
 %% This method is for creating device(s) on the fly
-start(Guid, User, Token)->
-  xaptum_client_sup:create(?MODULE, multi, #creds{guid = Guid, user = User, token = Token}).
+start(Guid, User, Token) when is_list(Guid) ->
+  start(Guid, User, Token, list_to_atom(Guid)).
+
+start(Guid, User, Token, RegName) when is_atom(RegName)->
+  xaptum_client_sup:create(?MODULE, multi, #creds{guid = Guid, user = User, token = Token, reg_name = RegName}).
 
 %% When single device is created from env, the message will be sent to the one device identified by env
 send_message(Message) ->
@@ -38,7 +42,7 @@ send_message(Message) ->
 %% However, device can be registered as any unique atom, which then can be used here instead of Guid
 %% TODO: consider using gproc to register with multiple names
 send_message(RegName, Message) when is_atom(RegName)->
-  gen_server:cast(RegName, {send_message, Message}).
+  gen_server:cast(RegName, {send_message, Message});
 send_message(Guid, Message) when is_list(Guid)->
   gen_server:cast(list_to_atom(Guid), {send_message, Message}).
 

--- a/src/xaptum_device.erl
+++ b/src/xaptum_device.erl
@@ -41,6 +41,8 @@ send_message(Message) ->
 %% Guid (= Ipv6 address) of the device is the initial reg name.
 %% However, device can be registered as any unique atom, which then can be used here instead of Guid
 %% TODO: consider using gproc to register with multiple names
+send_message(Pid, Message) when is_pid(Pid)->
+  gen_server:cast(Pid, {send_message, Message});
 send_message(RegName, Message) when is_atom(RegName)->
   gen_server:cast(RegName, {send_message, Message});
 send_message(Guid, Message) when is_list(Guid)->

--- a/src/xaptum_device.erl
+++ b/src/xaptum_device.erl
@@ -33,7 +33,12 @@ start(Guid, User, Token)->
 send_message(Message) ->
   gen_server:cast(?MODULE, {send_message, Message}).
 
-%% When multiple devices are created on the fly, need to identify device by Guid when sending a message
+%% When multiple devices are created on the fly, need to identify device by unique id when sending a message
+%% Guid (= Ipv6 address) of the device is the initial reg name.
+%% However, device can be registered as any unique atom, which then can be used here instead of Guid
+%% TODO: consider using gproc to register with multiple names
+send_message(RegName, Message) when is_atom(RegName)->
+  gen_server:cast(RegName, {send_message, Message}).
 send_message(Guid, Message) when is_list(Guid)->
   gen_server:cast(list_to_atom(Guid), {send_message, Message}).
 

--- a/src/xaptum_dummy_message_handler.erl
+++ b/src/xaptum_dummy_message_handler.erl
@@ -13,11 +13,11 @@
 -behavior(gen_xaptum).
 
 %% API
--export([async_handle_message/1]).
+-export([async_handle_message/2]).
 
 %% NOTE this message handling business can get complicated, so in real life it is
 %% best handled by a call to
 %% gen_server:cast(?MY_HANDLER_GEN_SERVER, Message) or a gen_fsm or something like that
-async_handle_message(Message)->
-  io:format("Got message: ~p~n", [Message]),
+async_handle_message(ParentPid, Message)->
+  io:format("Got message: ~p from ~p~n", [Message, ParentPid]),
   ok.

--- a/src/xaptum_subscriber.erl
+++ b/src/xaptum_subscriber.erl
@@ -24,6 +24,7 @@
 %% API
 -export([
   start/4,
+  start/5,
   send_message/2,
   send_message/3,
   populate_credentials/3,
@@ -31,16 +32,20 @@
   generate_message_request/3,
   not_created_warning_log/0]).
 
-start(Guid, User, Token, Queue) when is_list(Queue)->
-  start(Guid, User, Token, list_to_binary(Queue));
-start(Guid, User, Token, Queue) when is_binary(Queue)->
-  xaptum_client_sup:create(?MODULE, multi, #creds{guid = Guid, user = User, token = Token, queue = Queue}).
+start(Guid, User, Token, Queue) when is_list(Guid) ->
+  start(Guid, User, Token, Queue, list_to_atom(Guid)).
+
+start(Guid, User, Token, Queue, RegName) when is_list(Queue)->
+  start(Guid, User, Token, list_to_binary(Queue), RegName);
+start(Guid, User, Token, Queue, RegName) when is_binary(Queue), is_atom(RegName) ->
+  xaptum_client_sup:create(?MODULE, multi, #creds{guid = Guid, user = User, token = Token, queue = Queue, reg_name = RegName}).
+
 
 send_message(Message, DestinationGuid) ->
   gen_server:cast(?MODULE, {send_message, Message, DestinationGuid}).
 
 send_message(RegName, Message, DestinationGuid) when is_atom(RegName)->
-  gen_server:cast(RegName, {send_message, Message, DestinationGuid}).
+  gen_server:cast(RegName, {send_message, Message, DestinationGuid});
 send_message(SrcGuid, Message, DestinationGuid) when is_list(SrcGuid)->
   gen_server:cast(list_to_atom(SrcGuid), {send_message, Message, DestinationGuid}).
 

--- a/src/xaptum_subscriber.erl
+++ b/src/xaptum_subscriber.erl
@@ -32,8 +32,11 @@
   generate_message_request/3,
   not_created_warning_log/0]).
 
-start(Guid, User, Token, Queue) when is_list(Guid) ->
-  start(Guid, User, Token, Queue, list_to_atom(Guid)).
+%% TODO registering with the queue is temporary hack
+start(Guid, User, Token, Queue) when is_binary(Queue) ->
+  start(Guid, User, Token, Queue, binary_to_atom(Queue, utf8)).
+start(Guid, User, Token, Queue) when is_list(Queue) ->
+  start(Guid, User, Token, Queue, list_to_atom(Queue)).
 
 start(Guid, User, Token, Queue, RegName) when is_list(Queue)->
   start(Guid, User, Token, list_to_binary(Queue), RegName);

--- a/src/xaptum_subscriber.erl
+++ b/src/xaptum_subscriber.erl
@@ -39,6 +39,8 @@ start(Guid, User, Token, Queue) when is_binary(Queue)->
 send_message(Message, DestinationGuid) ->
   gen_server:cast(?MODULE, {send_message, Message, DestinationGuid}).
 
+send_message(RegName, Message, DestinationGuid) when is_atom(RegName)->
+  gen_server:cast(RegName, {send_message, Message, DestinationGuid}).
 send_message(SrcGuid, Message, DestinationGuid) when is_list(SrcGuid)->
   gen_server:cast(list_to_atom(SrcGuid), {send_message, Message, DestinationGuid}).
 

--- a/src/xaptum_subscriber.erl
+++ b/src/xaptum_subscriber.erl
@@ -34,7 +34,7 @@
 
 %% TODO registering with the queue is temporary hack
 start(Guid, User, Token, Queue) when is_binary(Queue) ->
-  start(Guid, User, Token, Queue, binary_to_atom(Queue, utf8)).
+  start(Guid, User, Token, Queue, binary_to_atom(Queue, utf8));
 start(Guid, User, Token, Queue) when is_list(Queue) ->
   start(Guid, User, Token, Queue, list_to_atom(Queue)).
 

--- a/templates/vars_gateway.config
+++ b/templates/vars_gateway.config
@@ -1,0 +1,3 @@
+{ type, xaptum_gateway }.
+{ xaptum_host, "mb.xaptum.net"}.
+{ node_name, "xaptum_gateway"}.


### PR DESCRIPTION
Support for "gateway" or "multi" mode.   Instead of setting env vars for a single xaptum_device or xaptum_subscriber, just start the xaptum_client app in gateway mode (as xaptum_gateway type) and add multiple xaptum_devices and/or xaptum_subscribers to one node on the fly (Providing credentials xaptum_device:start() or xaptum_subscriber:start() method signature. 